### PR TITLE
Update to weather application

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
             <h1 class="card-title city">London</h1>
             <h1 class="card-text font-weight-bold temp">33 C</h1>
             <button type="button" class="btn btn-outline-success mb-2 temp-btn" onclick="toggle()">
-              Switch to Farenheight
+              Switch to Fahrenheit
             </button>
             <p class="card-footer text-muted">We do not share your location.</p>
           </div>

--- a/index.html
+++ b/index.html
@@ -1,30 +1,27 @@
 <!DOCTYPE html>
 <html>
-
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width">
-	<title>Weather App</title>
-
-</head>
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
-<link rel="stylesheet" href="style.css">
-
-<body>
-  <div class="container-fluid">
-    <div class="card-center">
-      <div class="card col-sm-12 col-md-7 col-lg-3 rounded">
-        <div class="card-body">
-          <h1 class="card-title city">London</h1>
-          <h1 class="card-text font-weight-bold temp">33 C</h1>
-          <button type="button" class="btn btn-outline-success mb-2 temp-btn">Switch to Farenheight</button>
-          <p class="card-footer text-muted">We do not share your location.</p>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Weather App</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <link rel="stylesheet" href="style.css">
+  </head>
+  <body>
+    <div class="container-fluid">
+      <div class="card-center">
+        <div class="card col-sm-12 col-md-7 col-lg-3 rounded">
+          <div class="card-body">
+            <h1 class="card-title city">London</h1>
+            <h1 class="card-text font-weight-bold temp">33 C</h1>
+            <button type="button" class="btn btn-outline-success mb-2 temp-btn" onclick="toggle()">
+              Switch to Farenheight
+            </button>
+            <p class="card-footer text-muted">We do not share your location.</p>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-
-<script src="script.js"></script> 
-</body>
-
+    <script src="script.js"></script> 
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ const toggle = () => {
   let { units, selected } = weather;
   if (selected === 'F') {
     temp.innerHTML = `${units.find(u => u.type === 'C').value} C`;
-    tempBtn.innerHTML = 'Switch to Farenheight';
+    tempBtn.innerHTML = 'Switch to Fahrenheit';
     weather.selected = 'C';
   } else if (selected === 'C') {
     temp.innerHTML = `${units.find(u => u.type === 'F').value} F`;

--- a/script.js
+++ b/script.js
@@ -1,39 +1,39 @@
 const apiKey = '7f90da554b9e38ab6f360f884e8542e3'
+const endPoint = 'https://api.openweathermap.org/data/2.5/weather'
 
 const city = document.querySelector('.city')
 const temp = document.querySelector('.temp')
 const tempBtn = document.querySelector('.temp-btn')
 
-const getLocation = (position) => {
-  let lat = position.coords.latitude;
-  let long = position.coords.longitude;
-  fetch(`https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${long}&appid=${apiKey}&units=metric`)
+const getWeather = async ({ coords }) => {
+  let lat = coords.latitude;
+  let long = coords.longitude;
+  let data = await fetch(endPoint + `?lat=${lat}&lon=${long}&appid=${apiKey}&units=metric`)
     .then(response => response.json())
-    .then(data => {
-      console.log(data);
-      city.innerHTML = data.name;
-      let celcius = data.main.temp + ' C';
-      let farenheight = data.main.temp * 9 / 5 + 32 + ' F';
-      temp.innerHTML = celcius;
-    });
-}
-
-let displayTemp = 'c';
-
-tempBtn.addEventListener('click', () => {
-  if (displayTemp = 'c') {
-    temp.innerHTML = farenheight;
-    tempBtn.innerHTML = 'Switch to Farenheight'
-    let displayTemp = 'f';
-  } else if (displayTemp = 'f') {
-    temp.innerHTML = celcius;
-    tempBtn.innerHTML = 'Switch to Celcius';
-    let displayTemp = 'c';
+    .catch(console.error)
+  window.weather = {
+    city: data.name,
+    selected: 'C',
+    units: [
+      { type: 'F', value: Math.floor(data.main.temp) },
+      { type: 'C', value: Math.floor(data.main.temp * 9 / 5 + 32) }
+    ]
   }
-});
-
-const noLocation = (err) => {
-  console.error(err)
+  city.innerHTML = data.name;
+  temp.innerHTML = `${Math.floor(data.main.temp)} C`;
 }
 
-navigator.geolocation.getCurrentPosition(getLocation, noLocation)
+const toggle = () => {
+  let { units, selected } = weather;
+  if (selected === 'F') {
+    temp.innerHTML = `${units.find(u => u.type === 'C').value} C`;
+    tempBtn.innerHTML = 'Switch to Farenheight';
+    weather.selected = 'C';
+  } else if (selected === 'C') {
+    temp.innerHTML = `${units.find(u => u.type === 'F').value} F`;
+    tempBtn.innerHTML = 'Switch to Celsius';
+    weather.selected = 'F';
+  }
+}
+
+navigator.geolocation.getCurrentPosition(getWeather, console.error)

--- a/style.css
+++ b/style.css
@@ -1,8 +1,6 @@
 body {
-   background: rgb(236, 194, 10);
+  background: rgb(236, 194, 10);
 }
-
-
 
 .card-center {
   min-height: 100%;


### PR DESCRIPTION
Weather can now be toggled between Celsius and Fahrenheit

Weather application is started with:
`navigator.geolocation.getCurrentPosition(getWeather, console.error)`
(Either gets the weather or logs the error to the console)

`weather` is attached to the `window` so it is a global variable
(Useful for debugging)

We store the weather globally so we only need to request it from the weather api nonce

The `fetch` api logs failed http requests to weather api

We use `Math.floor` to round down weather

The `.temp-btn` uses an `onclick` attribute that triggers `toggle`

Code formatting was cleaned up

`Celcius` was renamed to the correct spelling `Celsius`

`Farenheight` was renamed to the correct spelling `Fahrenheit`

Moved api endpoint to top